### PR TITLE
sepolicy: small cleanup

### DIFF
--- a/sepolicy/fingerprintd.te
+++ b/sepolicy/fingerprintd.te
@@ -6,4 +6,3 @@ allow fingerprintd fingerprint_dir:dir rw_dir_perms;
 allow fingerprintd fingerprint_dir:file create_file_perms;
 allow fingerprintd fingerprint_device:chr_file { open read write ioctl };
 allow fingerprintd fingerprint_metadata:file create_file_perms;
-allow fingerprintd fingerprint_metadata:file rw_file_perms;

--- a/sepolicy/isolated_app.te
+++ b/sepolicy/isolated_app.te
@@ -1,3 +1,0 @@
-allow isolated_app app_data_file:dir search;
-allow isolated_app app_data_file:file ioctl;
-allow isolated_app untrusted_app:unix_stream_socket ioctl;

--- a/sepolicy/qseecomd.te
+++ b/sepolicy/qseecomd.te
@@ -1,9 +1,5 @@
 # Fingerprint sensor
 allow tee fingerprint_data:dir create_dir_perms;
-allow tee fingerprint_data:dir rw_dir_perms;
 allow tee fingerprint_data:file create_file_perms;
-allow tee fingerprint_data:file rw_file_perms;
 allow tee fingerprint_dir:dir create_dir_perms;
-allow tee fingerprint_dir:dir rw_dir_perms;
 allow tee fingerprint_dir:file create_file_perms;
-allow tee fingerprint_dir:file rw_file_perms;

--- a/sepolicy/untrusted_app.te
+++ b/sepolicy/untrusted_app.te
@@ -1,3 +1,0 @@
-allow untrusted_app self:udp_socket ioctl;
-allow untrusted_app recovery_cache_file:dir getattr;
-allow untrusted_app tombstone_data_file:dir search;


### PR DESCRIPTION
* create_file_perms already has rw_file_perms so no need to include it twice
* untrusted_app is doing nothing, same for isolated_app

Change-Id: I742bf0410bb644304cb4b999351d9193ae0c51e4